### PR TITLE
custom installation prompt for ios devices

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,43 @@
 <template>
   <router-view />
   <!-- <AddToHomeScreen /> -->
+  <div v-show="showInstallPrompt" class="install-banner" @click="showInstallationGuide">
+    Install App
+  </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+  const isIos = () => {
+    const userAgent = window.navigator.userAgent.toLowerCase();
+    return /iphone|ipad|ipod/.test(userAgent);
+  };
+  const isInStandaloneMode = () => "standalone" in window.navigator && window.navigator.standalone;
+
+  const showInstallPrompt = ref(isIos() && !isInStandaloneMode());
+
+  const showInstallationGuide = () => {
+    // remove following line if you want to show the banner after installation
+    showInstallPrompt.value = false;
+    alert(
+      'To install this app on device:\n\n1. Tap the "Share" button (usually located at the bottom of the screen).\n\n2. Scroll down and find the "Add to Home Screen" option.\n\n3. Tap "Add" in the upper-right corner.\n\nNow, you can access the app from your home screen!'
+    );
+  };
+</script>
 
 <style>
   input {
     background-clip: text !important;
     -webkit-background-clip: text !important;
+  }
+  .install-banner {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    background-color: #007bff;
+    color: #fff;
+    padding: 8px 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    font: 12px sans-serif;
   }
 </style>


### PR DESCRIPTION
### Changes Made
- Added a fixed small button with the text "Install App" to prompt users to install the PWA on iOS devices.
- Implemented logic to show the banner only if the user is on an iOS device and not in standalone mode.
- Added a custom installation prompt with instructions on how to add the app to the home screen on iOS.
- Modified the behaviour to hide the button after the user installs the app. (reset on refresh - for now)

### Context
- The button is added to improve the user experience by guiding iOS users through the installation process.
- The custom installation prompt provides clear instructions for adding the app to the home screen.
- The banner is now hidden after the user follows the installation steps, providing a cleaner interface.

### Additional Notes
- The styling of the button can be further customized based on design preferences. (maybe create a banner instead)
- The solution is tested on various iOS devices and browsers to ensure compatibility.

